### PR TITLE
fix add button link on resources page

### DIFF
--- a/src/components/Resources/index.js
+++ b/src/components/Resources/index.js
@@ -102,13 +102,11 @@ class Resources extends Component {
             </div>
           );
         })}
-        <Addresource>
-          <h5>
-            <WebLink href="https://forms.gle/CVMbXaZjVk1tnwjDA" target="_blank">
-              Add Educational Material
-            </WebLink>
-          </h5>
-        </Addresource>
+        <WebLink href="https://forms.gle/CVMbXaZjVk1tnwjDA" target="_blank">
+          <Addresource>
+            <h5>Add Educational Material</h5>
+          </Addresource>
+        </WebLink>
       </div>
     );
   }


### PR DESCRIPTION
I noticed just a small UI bug on the resources page:

- The link did not fully cover the "Add Educational Material" button

Before:
https://i.gyazo.com/327e5a24a864433ca46cb7d8bae10335.mp4

After (form opens in new tab):
https://i.gyazo.com/f382c9fecba4f7a23e0c25b025349d6a.mp4