### PR TITLE
Experimental Netlify function setup for eventual FaunaDB integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+# netlify
+.netlify

--- a/functions/resources/resources.js
+++ b/functions/resources/resources.js
@@ -1,0 +1,15 @@
+
+
+
+
+function resources(event, context, callback) {
+    callback(null, {
+        statusCode: 200,
+        body: "From the server!"
+    });
+}
+
+
+exports.handler = resources;
+
+

--- a/functions/resources/resources.js
+++ b/functions/resources/resources.js
@@ -3,9 +3,11 @@
 
 
 function resources(event, context, callback) {
+    console.log("\nOn the server!\n");
     callback(null, {
         statusCode: 200,
-        body: "From the server!"
+        // Must stringify as JSON if we want a JSON response body back
+        body: JSON.stringify("Server!")
     });
 }
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,5 @@
+[build]
+  functions = "./functions"
+
+[dev]
+  functionsPort = 34567

--- a/src/components/Resources/AddResource.js
+++ b/src/components/Resources/AddResource.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useState } from "react";
 import axios from "axios";
 import styled from "styled-components";
 
@@ -6,8 +6,8 @@ import styled from "styled-components";
 
 const Addresource = styled.div`
     position: fixed;
-    top: 92vh;
-    left: 80vw;
+    right: 7.5%;
+    bottom: 0;
     min-height: 10vh;
     background-color: black;
     border-top: solid 2px gray;
@@ -29,27 +29,43 @@ const WebLink = styled.a`
     }
 `;
 
+const Function = styled.div`
+    display: flex;
+    align-items: center;
+    justify-content: space-evenly;
+    font-weight: bold;
+    height: 2em;
+    margin: 0.5em 0 0;
+`;
+
+const Call = styled.button`
+    font-size: 0.875em !important;
+    height: 100%;
+    width: 50%;
+`;
+
 
 export default function AddResource() {
     const [text, setText] = useState("Browser!");
-    useEffect(() => {
+    const netlifyFunction = async () => {
         if (text === "Browser!") {
-            const lambda = async () => {
-                const res = await axios.get(".netlify/functions/resources");
-                setText(res.data);
-            }
-            lambda();
+            const res = await axios.get(".netlify/functions/resources");
+            setText(res.data);
         }
-    }, [text]);
+    };
     return (
-        <WebLink href="https://forms.gle/CVMbXaZjVk1tnwjDA" target="_blank">
-            <Addresource>
+        <Addresource>
+            <WebLink href="https://forms.gle/CVMbXaZjVk1tnwjDA" target="_blank">
                 <h5>Add Educational Material</h5>
+            </WebLink>
+            <Function>
+                <Call onClick={() => netlifyFunction()}>
+                    Function
+                </Call>
                 {text}
-            </Addresource>
-        </WebLink>
+            </Function>
+        </Addresource>
     );
 }
-
 
 

--- a/src/components/Resources/AddResource.js
+++ b/src/components/Resources/AddResource.js
@@ -1,4 +1,5 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
+import axios from "axios";
 import styled from "styled-components";
 
 
@@ -30,13 +31,18 @@ const WebLink = styled.a`
 
 
 export default function AddResource() {
-    const [text, setText] = useState("From the browser!");
+    const [text, setText] = useState("Browser!");
+    useEffect(() => {
+        if (text === "Browser!") {
+            const lambda = async () => {
+                const res = await axios.get(".netlify/functions/resources");
+                setText(res.data);
+            }
+            lambda();
+        }
+    }, [text]);
     return (
-        <WebLink
-            href="https://forms.gle/CVMbXaZjVk1tnwjDA"
-            target="_blank"
-            onClick={() => console.log("test")}
-        >
+        <WebLink href="https://forms.gle/CVMbXaZjVk1tnwjDA" target="_blank">
             <Addresource>
                 <h5>Add Educational Material</h5>
                 {text}

--- a/src/components/Resources/AddResource.js
+++ b/src/components/Resources/AddResource.js
@@ -1,0 +1,49 @@
+import React, { useState } from "react";
+import styled from "styled-components";
+
+
+
+const Addresource = styled.div`
+    position: fixed;
+    top: 92vh;
+    left: 80vw;
+    min-height: 10vh;
+    background-color: black;
+    border-top: solid 2px gray;
+    border-radius: 25px 25px 0 0;
+    padding: 1em;
+    transition: 1s;
+    color: white;
+    cursor: pointer;
+    :hover {
+        background-color: orange;
+    }
+`;
+
+const WebLink = styled.a`
+    color: white;
+    transition: 0.3s;
+    :hover {
+        color: black;
+    }
+`;
+
+
+export default function AddResource() {
+    const [text, setText] = useState("From the browser!");
+    return (
+        <WebLink
+            href="https://forms.gle/CVMbXaZjVk1tnwjDA"
+            target="_blank"
+            onClick={() => console.log("test")}
+        >
+            <Addresource>
+                <h5>Add Educational Material</h5>
+                {text}
+            </Addresource>
+        </WebLink>
+    );
+}
+
+
+

--- a/src/components/Resources/index.js
+++ b/src/components/Resources/index.js
@@ -15,7 +15,7 @@ class Resources extends Component {
         categories: []
     };
     componentDidMount() {
-        var resourceData = async () => {
+        const resourceData = async () => {
             const resp = await axios.get("https://natespilman.tech/jdsb/resources/");
             const data = await resp.data;
             const headers = await data[0].map(json =>

--- a/src/components/Resources/index.js
+++ b/src/components/Resources/index.js
@@ -1,115 +1,83 @@
 import React, { Component } from "react";
 import axios from "axios";
-import styled from "styled-components";
 
 import Resource from "./Resource";
+import AddResource from "./AddResource";
 
 // Currently unused
 // import { SkeletonLine } from '../UI/Skeleton'
 
-const Addresource = styled.div`
-  position: fixed;
-  top: 92vh;
-  left: 80vw;
-  min-height: 10vh;
-  background-color: black;
-  border-top: solid 2px gray;
-  border-radius: 25px 25px 0 0;
-  padding: 1em;
-  transition: 1s;
-  color: white;
-  cursor: pointer;
-  :hover {
-    background-color: orange;
-  }
-`;
 
-const WebLink = styled.a`
-  color: white;
-  transition: 0.3s;
-  :hover {
-    color: black;
-  }
-`;
 
 class Resources extends Component {
-  state = {
-    resources: [],
-    categories: []
-  };
-  componentDidMount() {
-    var resourceData = async () => {
-      const resp = await axios.get("https://natespilman.tech/jdsb/resources/");
-      const data = await resp.data;
-      const headers = await data[0].map(json =>
-        json
-          .toLowerCase()
-          .replace(/ /g, "")
-          .replace(/[{()}]/g, "")
-      );
-      data.shift();
-
-      const resources = [];
-      await data.forEach(line => {
-        const obj = {};
-        for (let i = 0; i < line.length; i++) {
-          obj[headers[i]] = line[i];
-        }
-        resources.push(obj);
-      });
-      const categories = [
-        ...new Set(resources.map(resource => resource["language/topic"]))
-      ];
-      this.setState({ resources });
-      this.setState({ categories });
+    state = {
+        resources: [],
+        categories: []
     };
-    resourceData();
-  }
-
-  render() {
-    if (this.state.resources.length === 0) {
-      return (
-        <div style={{ color: "black" }} className="container">
-          <h1>Loading Resources</h1>
-          <Resource skeleton={true} />
-          <Resource skeleton={true} />
-          <Resource skeleton={true} />
-          <Resource skeleton={true} />
-          <Resource skeleton={true} />
-        </div>
-      );
+    componentDidMount() {
+        var resourceData = async () => {
+            const resp = await axios.get("https://natespilman.tech/jdsb/resources/");
+            const data = await resp.data;
+            const headers = await data[0].map(json =>
+                json.toLowerCase().replace(/ /g, "").replace(/[{()}]/g, "")
+            );
+            data.shift();
+            
+            const resources = [];
+            await data.forEach(line => {
+                const obj = {};
+                for (let i = 0; i < line.length; i++) {
+                    obj[headers[i]] = line[i];
+                }
+                resources.push(obj);
+            });
+            const categories = [
+                ...new Set(resources.map(resource => resource["language/topic"]))
+            ];
+            this.setState({ resources });
+            this.setState({ categories });
+        };
+        resourceData();
     }
-
-    const { categories } = this.state;
-    return (
-      <div className="container">
-        {categories.map(category => {
-          const resources = this.state.resources.filter(
-            resource => resource["language/topic"] === category
-          );
-          return (
-            <div
-              style={{
-                padding: "1em"
-              }}
-            >
-              <h2 className="text-left">{category}</h2>
-              <div>
-                {resources.map(resource => (
-                  <Resource resource={resource} />
-                ))}
-              </div>
+    
+    render() {
+        if (this.state.resources.length === 0) {
+            return (
+                <div style={{ color: "black" }} className="container">
+                    <h1>Loading Resources</h1>
+                    <Resource skeleton={true} />
+                    <Resource skeleton={true} />
+                    <Resource skeleton={true} />
+                    <Resource skeleton={true} />
+                    <Resource skeleton={true} />
+                </div>
+            );
+        }
+        
+        const { categories } = this.state;
+        return (
+            <div className="container">
+                {categories.map(category => {
+                    const resources = this.state.resources.filter(
+                        resource => resource["language/topic"] === category
+                    );
+                    return (
+                        <div style={{ padding: "1em" }}>
+                            <h2 className="text-left">{category}</h2>
+                            <div>
+                                {resources.map(resource => (
+                                    <Resource resource={resource} />
+                                ))}
+                            </div>
+                        </div>
+                    );
+                })}
+                <AddResource/>
             </div>
-          );
-        })}
-        <WebLink href="https://forms.gle/CVMbXaZjVk1tnwjDA" target="_blank">
-          <Addresource>
-            <h5>Add Educational Material</h5>
-          </Addresource>
-        </WebLink>
-      </div>
-    );
-  }
+        );
+    }
 }
 
 export default Resources;
+
+


### PR DESCRIPTION
I have an operational Netlify function implemented successfully.  It can be executed on the Resources page via the placeholder function button that I created on the add resources widget.  This will simply modify the text to the right of the button and update it with output supplied by the called Netlify function.

While everything works just fine, there are some important caveats.  If we want to move forward with this Netlify function and FaunaDB integration, it will likely change how the community will be able to continue contributing to the website.

You will notice that there is now a `netlify.toml` file that I've included in my PR.  This is going to be important in order to allow others to contribute to developing Netlify functions for the website and in other community projects.

Additionally, simply running `npm start` locally will no longer be sufficient in order for people to work on their own separate forks of the site.  With Netlify, we will now need to start using [Netlify Dev](https://github.com/netlify/cli/blob/master/docs/netlify-dev.md) in order to build, test, and use Netlify functions locally.  This means making updates to our `README.md` file and properly fleshing out proper contributing guidelines and development instructions as is mentioned in issue #15.

Finally, it appears that using `netlify dev` may require access to the `siteId` environment variable in order to use Netlify functions locally.  It also exposes access to `netlify deploy` which means contributors could accidentally or maliciously deploy to production from their local machines and potentially bypass the existing automated deployment process that is currently used.  The `siteId` value is stored in a `.netlify` folder that's generated by using `netlify link` as is [explained in detail here](https://docs.netlify.com/cli/get-started/#link-and-unlink-sites).  By default, `.netlify` is hidden from git which suggests it should not be committed.  We don't want to accidentally expose sensitive data on the website, so we may need to find a way to safely expose the `siteId` variable so that the community can continue to contribute to the site.  We also don't want to allow other deploys without them going through our existing protocols, so we will need to make sure to block this off somehow.

I would recommend that whoever reviews this PR try to run it locally without having to use `netlify link` or the `siteId` variable as a sanity check.  If you're able to get it to work without these two things, then perhaps this won't be an issue after all.  If it does happen to be an issue, we will need to figure out a workaround for this problem.

One more thing: while the function I wrote works when called from the resources page, it does not appear to work when using `netlify functions:invoke`.  Instead, the following error and stack trace is produced:

```bash
ran into an error invoking your function
{ FetchError: request to http://localhost:8888/.netlify/functions/resources failed, reason: connect ECONNREFUSED 127.0.0.1:8888
    at ClientRequest.<anonymous> (/Users/xoadra/.nvm/versions/node/v10.16.0/lib/node_modules/netlify-cli/node_modules/node-fetch/lib/index.js:1455:11)
    at ClientRequest.emit (events.js:198:13)
    at Socket.socketErrorListener (_http_client.js:392:9)
    at Socket.emit (events.js:198:13)
    at emitErrorNT (internal/streams/destroy.js:91:8)
    at emitErrorAndCloseNT (internal/streams/destroy.js:59:3)
    at process._tickCallback (internal/process/next_tick.js:63:19)
  message:
   'request to http://localhost:8888/.netlify/functions/resources failed, reason: connect ECONNREFUSED 127.0.0.1:8888',
  type: 'system',
  errno: 'ECONNREFUSED',
  code: 'ECONNREFUSED' }
```

You can read more about the `netlify functions:invoke` command [via their docs](https://github.com/netlify/cli/blob/master/docs/netlify-dev.md#locally-testing-functions-with-netlify-functionsinvoke) if you'd like.  While this doesn't appear to affect the function's usability on the website, it's good to be aware that this issue exists in the event it rears its head in another situation in the future.

Let me know if you run into any issues when running this code.  Otherwise, I look forward to working on the next step with @nspilman!