### PR TITLE
Fix part of #35: Use index as key for mapping over bodList and execList

### DIFF
--- a/src/components/Organization/index.js
+++ b/src/components/Organization/index.js
@@ -101,9 +101,9 @@ const Organization = props => {
         <h4 style={{ color: "white", padding: "0 0 1em 0" }}>
           Board of Directors
         </h4>
-        {bodList.map(position => {
+        {bodList.map((position, index) => {
           return (
-            <Position>
+            <Position key={index}>
               {position.title} - {position.name}
             </Position>
           );
@@ -112,9 +112,9 @@ const Organization = props => {
         <h4 style={{ color: "white", padding: "1em 0 1em 0" }}>
           Executive Team
         </h4>
-        {execList.map(position => {
+        {execList.map((position, index) => {
           return (
-            <Position>
+            <Position key={index}>
               {position.title} - {position.name}
             </Position>
           );


### PR DESCRIPTION
This PR only addresses `/Organization`'s list children of `execList` and `bodList` missing key.

As @Xoadra has mentioned, I agree that we can use the map's index as key for the list's children.
@Xoadra thanks for the quick reply :) PTAL