### PR TITLE
Fix #35: Missing key for list children on Resources page

### DIFF
--- a/src/components/Resources/index.js
+++ b/src/components/Resources/index.js
@@ -88,7 +88,7 @@ class Resources extends Component {
             resource => resource["language/topic"] === category
           );
           return (
-            <div
+            <div key={category}
               style={{
                 padding: "1em"
               }}
@@ -96,7 +96,7 @@ class Resources extends Component {
               <h2 className="text-left">{category}</h2>
               <div>
                 {resources.map(resource => (
-                  <Resource resource={resource} />
+                  <Resource key={resource.link} resource={resource} />
                 ))}
               </div>
             </div>


### PR DESCRIPTION
For `/Resources`, there are two big lists: Category list and the Resources-by-Category list.
1. For the category list, each category is unique by nature so I opted to use the category as key for its list children.
2. For the resources-by-category list, @Xoadra suggested to use resource's link so I have done exactly that.
This should be a wrap for #35? @Xoadra 